### PR TITLE
Server start/stop button control

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -15,7 +15,12 @@ yargs.command({
     });
   },
   handler: function handler(argv) {
-    server.serve(argv.directory, argv.port);
+    server.serve(argv.directory, argv.port, function (status, data) {
+      if (status === 'error') {
+        console.log('Error:');
+        console.log(data.message);
+      }
+    });
   },
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -98,9 +98,16 @@ ipcMain.on('server-start', (event, args) => {
     srv.close()
   }
 
-  srv = server.serve(args.directory, args.port)
-
-  event.sender.send('server-started')
+  server.serve(args.directory, args.port, (status, data) => {
+    if (status === 'ok') {
+      event.sender.send('server-started')
+      srv = data.server;
+    } else {
+      event.sender.send('server-error', {
+        code: data.code,
+      })
+    }
+  })
 })
 
 ipcMain.on('server-stop', (event) => {

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -16,8 +16,8 @@
       </v-row>
       <v-row>
         <v-col cols="12">
-          <v-btn v-on:click="startServer" class="mr-4">Start</v-btn>
-          <v-btn v-on:click="stopServer">Stop</v-btn>
+          <v-btn v-on:click="startServer" v-bind:disabled="startButtonDisabled()" color="light-green" class="mr-4">Start</v-btn>
+          <v-btn v-on:click="stopServer" v-bind:disabled="stopButtonDisabled()" color="amber">Stop</v-btn>
         </v-col>
       </v-row>
       <v-row>
@@ -58,6 +58,7 @@ export default {
   data: () => ({
     directory: '',
     port: '3000',
+    serverIsRunning: false,
     log: '',
   }),
   methods: {
@@ -79,14 +80,22 @@ export default {
     stopServer() {
       ipcRenderer.send('server-stop');
     },
+    startButtonDisabled() {
+      return this.serverIsRunning === true;
+    },
+    stopButtonDisabled() {
+      return this.serverIsRunning === false;
+    },
   },
   mounted() {
     // Temporary implementation
     ipcRenderer.on('server-started', () => {
+      this.serverIsRunning = true;
       this.log += 'started<br>';
     });
 
     ipcRenderer.on('server-stopped', () => {
+      this.serverIsRunning = false;
       this.log += 'stopped<br>';
     });
   },

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -20,6 +20,11 @@
           <v-btn v-on:click="stopServer" v-bind:disabled="stopButtonDisabled()" color="amber">Stop</v-btn>
         </v-col>
       </v-row>
+      <v-row>
+        <v-col cols="12">
+          <div>{{ errorReason }}</div>
+        </v-col>
+      </v-row>
     </v-container>
   </v-form>
 </template>
@@ -56,6 +61,7 @@ export default {
     directory: '',
     port: '3000',
     serverIsRunning: false,
+    errorReason: '',
   }),
   methods: {
     selectDirectory() {
@@ -86,9 +92,15 @@ export default {
   mounted() {
     ipcRenderer.on('server-started', () => {
       this.serverIsRunning = true;
+      this.errorReason = '';
     });
     ipcRenderer.on('server-stopped', () => {
       this.serverIsRunning = false;
+      this.errorReason = '';
+    });
+    ipcRenderer.on('server-error', (event, args) => {
+      this.serverIsRunning = false;
+      this.errorReason = (args.code === 'EADDRINUSE') ? 'port is already used.' : 'unknown error.';
     });
   },
 };

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -101,9 +101,3 @@ export default {
   },
 };
 </script>
-
-<style>
-.directory {
-  width: 300px;
-}
-</style>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -11,7 +11,7 @@
       </v-row>
       <v-row>
         <v-col cols="4">
-          <v-text-field v-model="port" prefix="http://localhost" suffix="/"></v-text-field>
+          <v-text-field v-model="port" prefix="http://localhost:" suffix="/"></v-text-field>
         </v-col>
       </v-row>
       <v-row>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -20,9 +20,6 @@
           <v-btn v-on:click="stopServer" v-bind:disabled="stopButtonDisabled()" color="amber">Stop</v-btn>
         </v-col>
       </v-row>
-      <v-row>
-        <div v-html="log" class="log"></div>
-      </v-row>
     </v-container>
   </v-form>
 </template>
@@ -59,7 +56,6 @@ export default {
     directory: '',
     port: '3000',
     serverIsRunning: false,
-    log: '',
   }),
   methods: {
     selectDirectory() {
@@ -88,15 +84,11 @@ export default {
     },
   },
   mounted() {
-    // Temporary implementation
     ipcRenderer.on('server-started', () => {
       this.serverIsRunning = true;
-      this.log += 'started<br>';
     });
-
     ipcRenderer.on('server-stopped', () => {
       this.serverIsRunning = false;
-      this.log += 'stopped<br>';
     });
   },
 };

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -3,21 +3,41 @@
     <v-container>
       <v-row>
         <v-col cols="8">
-          <v-text-field v-model="directory" v-bind:rules="rulesDirectory()" placeholder="directory"></v-text-field>
+          <v-text-field
+            v-model="directory"
+            v-bind:rules="rulesDirectory()"
+            placeholder="directory"
+          ></v-text-field>
         </v-col>
         <v-col cols="4">
-          <v-btn v-on:click="selectDirectory">Browse</v-btn>
+          <v-btn
+            v-on:click="selectDirectory"
+          >Browse</v-btn>
         </v-col>
       </v-row>
       <v-row>
         <v-col cols="4">
-          <v-text-field v-model="port" v-bind:rules="rulesPort()" prefix="http://localhost:" suffix="/"></v-text-field>
+          <v-text-field
+            v-model="port"
+            v-bind:rules="rulesPort()"
+            prefix="http://localhost:"
+            suffix="/"
+          ></v-text-field>
         </v-col>
       </v-row>
       <v-row>
         <v-col cols="12">
-          <v-btn v-on:click="startServer" v-bind:disabled="startButtonDisabled()" color="light-green" class="mr-4">Start</v-btn>
-          <v-btn v-on:click="stopServer" v-bind:disabled="stopButtonDisabled()" color="amber">Stop</v-btn>
+          <v-btn
+            v-on:click="startServer"
+            v-bind:disabled="startButtonDisabled()"
+            color="light-green"
+            class="mr-4"
+          >Start</v-btn>
+          <v-btn
+            v-on:click="stopServer"
+            v-bind:disabled="stopButtonDisabled()"
+            color="amber"
+          >Stop</v-btn>
         </v-col>
       </v-row>
     </v-container>
@@ -53,7 +73,6 @@ export default {
       ];
     },
     rulesPort() {
-      // const that = this;
       return [
         () => {
           return this.errorCode === 'EADDRINUSE' ? 'Port is already used.' : true;

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -41,6 +41,16 @@
         </v-col>
       </v-row>
     </v-container>
+    <v-dialog
+      v-model="dialog"
+      max-width="300"
+    >
+      <v-card>
+        <v-card-title></v-card-title>
+        <v-card-text>Unknown error.</v-card-text>
+        <v-card-actions></v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-form>
 </template>
 
@@ -52,6 +62,7 @@ const { dialog } = require('electron').remote; // eslint-disable-line
 export default {
   name: 'home',
   data: () => ({
+    dialog: false,
     directory: '',
     port: '3000',
     serverIsRunning: false,
@@ -121,10 +132,13 @@ export default {
       this.errorCode = '';
     });
     ipcRenderer.on('server-error', (event, args) => {
-      // TODO: Handle unknown error (args.code !== 'EADDRINUSE')
       this.serverIsRunning = false;
       this.errorCode = args.code;
       this.$refs.form.validate();
+
+      if (args.code !== 'EADDRINUSE') {
+        this.dialog = true;
+      }
     });
   },
 };


### PR DESCRIPTION
#22 

### ボタン制御

- サーバー起動中は 'Start' がクリックできない
- サーバー停止中は 'Stop' がクリックできない

### エラーハンドリング

- 指定したポートが既にに使用されているケースに対応する。
  - エラーコード: `EADDRINUSE`
  - `server.on('error', (e) => { ... }`
- `server.listen()` が非同期なので、処理の見直し必要。

[net.Server.listen()](https://nodejs.org/api/net.html#net_server_listen)

#### サーバークラス

`http.Server` extends `net.Server`
- [http.Server](https://nodejs.org/api/http.html#http_class_http_server)
- [net.Server](https://nodejs.org/api/net.html#net_class_net_server)